### PR TITLE
Create state root precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2730,6 +2730,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "eyre",
+ "reqwest",
  "reth",
  "reth-chainspec",
  "reth-evm-ethereum",
@@ -2738,6 +2739,7 @@ dependencies = [
  "reth-node-ethereum",
  "reth-primitives",
  "reth-tracing",
+ "serde_json",
  "tokio",
 ]
 

--- a/examples/custom-evm/Cargo.toml
+++ b/examples/custom-evm/Cargo.toml
@@ -19,3 +19,6 @@ alloy-primitives.workspace = true
 
 eyre.workspace = true
 tokio.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+


### PR DESCRIPTION
The implemented precompile fetches the Arbitrum state root from an external service and returns it to the EVM. Such external service is supposed to be an Arbitrum node with the JSON-RPC opened on the port `8547`.

The precompile has been registered in the address `0000000000000000000000000000000000000111`.

A retry on failures feature has been included to make the solution more resilient.